### PR TITLE
Support delimiter for MergeTokens

### DIFF
--- a/hojichar/filters/tokenization.py
+++ b/hojichar/filters/tokenization.py
@@ -2,6 +2,7 @@ from typing import List
 
 from hojichar.core.filter_interface import Filter
 from hojichar.core.models import Document
+from typing import Any
 
 
 class BlankCharTokenizer(Filter):
@@ -29,12 +30,19 @@ class MergeTokens(Filter):
     破棄されていないトークンを結合し, Document を更新します.
     """
 
+    def __init__(self, delimiter: str = "", *args: Any, **kwargs: Any) -> None:
+        super().__init__(*args, **kwargs)
+        self.delimiter = delimiter
+
     def merge(self, tokens: List[str]) -> str:
         """
         >>> MergeTokens().merge(["hoo", "bar"])
         'hoobar'
+
+        >>> MergeTokens("\\n").merge(["hoo", "bar"])
+        'hoo\\nbar'
         """
-        return "".join(tokens)
+        return self.delimiter.join(tokens)
 
     def apply(self, document: Document) -> Document:
         remained_tokens = [token.text for token in document.tokens if not token.is_rejected]

--- a/tests/filters/test_tokenization.py
+++ b/tests/filters/test_tokenization.py
@@ -1,0 +1,17 @@
+from hojichar.core.models import Document
+from hojichar.filters import tokenization
+
+
+class TestMergeTokens:
+    def test_merge(self):
+        doc = Document("おはよう。おやすみ。ありがとう。さよなら。")
+        tokenizer = tokenization.SentenceTokenizer()
+        transformed_doc = tokenizer.apply(doc)
+        assert [
+            "おはよう。",
+            "おやすみ。",
+            "ありがとう。",
+            "さよなら。",
+        ] == transformed_doc.get_tokens()
+        assert "おはよう。おやすみ。ありがとう。さよなら。" == tokenization.MergeTokens().apply(transformed_doc).text
+        assert "おはよう。\nおやすみ。\nありがとう。\nさよなら。" == tokenization.MergeTokens("\n").apply(transformed_doc).text


### PR DESCRIPTION
## What

This pr enables users to use a delimiter when you use `document_filters.MergeTokens`.

## Motivation

After processing tokens that you tokenize from a document text by some delimiters, you may want to concat those tokens by the delimiters.

```py
doc = Document("hoo\nbar")
doc.set_tokens(["hoo", "bar"])

document_filters.MergeTokens().apply(doc)
# Document.text => "hoobar"
document_filters.MergeTokens("\n").apply(doc)
# Document.text => "hoo\nbar"
```